### PR TITLE
Add unit tests and simple cylinder/SLMP modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,13 @@ a
 a
 a
 a
+
+## Running Tests
+
+To execute the unit tests, install the dependencies (pytest) and run:
+
+```bash
+pytest
+```
+
+The test suite covers cylinder state transitions for 2-position and 3-position modes as well as SLMP message encoding/decoding.

--- a/cylinder.py
+++ b/cylinder.py
@@ -1,0 +1,34 @@
+class Cylinder:
+    """Simple cylinder model supporting 2-position and 3-position modes."""
+
+    POS_RETRACTED = "retracted"
+    POS_EXTENDED = "extended"
+    POS_INTERMEDIATE = "intermediate"
+
+    def __init__(self, mode="2-position"):
+        if mode not in {"2-position", "3-position"}:
+            raise ValueError("mode must be '2-position' or '3-position'")
+        self.mode = mode
+        self.position = self.POS_RETRACTED
+
+    def extend(self):
+        self.position = self.POS_EXTENDED
+
+    def retract(self):
+        self.position = self.POS_RETRACTED
+
+    def intermediate(self):
+        if self.mode != "3-position":
+            raise ValueError("intermediate position only valid in 3-position mode")
+        self.position = self.POS_INTERMEDIATE
+
+    def get_position_signals(self):
+        signals = {
+            self.POS_RETRACTED: False,
+            self.POS_EXTENDED: False,
+            self.POS_INTERMEDIATE: False,
+        }
+        signals[self.position] = True
+        if self.mode == "2-position":
+            signals.pop(self.POS_INTERMEDIATE)
+        return signals

--- a/slmp.py
+++ b/slmp.py
@@ -1,0 +1,19 @@
+class SLMPMessage:
+    """Very small placeholder implementation for SLMP messages."""
+
+    def __init__(self, command: str, address: int, data: bytes):
+        self.command = command
+        self.address = address
+        self.data = data
+
+    def encode(self) -> bytes:
+        # This is NOT a real SLMP implementation, just a placeholder for testing
+        header = f"{self.command}:{self.address}:".encode()
+        return header + self.data
+
+    @classmethod
+    def decode(cls, payload: bytes):
+        # extremely naive decoding matching the encode above
+        header, data = payload.split(b":", 2)[:2], payload.split(b":", 2)[2]
+        command, address = header[0].decode(), int(header[1])
+        return cls(command, address, data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_cylinder.py
+++ b/tests/test_cylinder.py
@@ -1,0 +1,54 @@
+import pytest
+
+from cylinder import Cylinder
+
+
+def test_2_position_transitions():
+    cyl = Cylinder(mode="2-position")
+
+    assert cyl.position == Cylinder.POS_RETRACTED
+    assert cyl.get_position_signals() == {
+        Cylinder.POS_RETRACTED: True,
+        Cylinder.POS_EXTENDED: False,
+    }
+
+    cyl.extend()
+    assert cyl.position == Cylinder.POS_EXTENDED
+    assert cyl.get_position_signals() == {
+        Cylinder.POS_RETRACTED: False,
+        Cylinder.POS_EXTENDED: True,
+    }
+
+    cyl.retract()
+    assert cyl.position == Cylinder.POS_RETRACTED
+
+    with pytest.raises(ValueError):
+        cyl.intermediate()
+
+
+def test_3_position_transitions():
+    cyl = Cylinder(mode="3-position")
+
+    cyl.extend()
+    assert cyl.position == Cylinder.POS_EXTENDED
+    assert cyl.get_position_signals() == {
+        Cylinder.POS_RETRACTED: False,
+        Cylinder.POS_EXTENDED: True,
+        Cylinder.POS_INTERMEDIATE: False,
+    }
+
+    cyl.intermediate()
+    assert cyl.position == Cylinder.POS_INTERMEDIATE
+    assert cyl.get_position_signals() == {
+        Cylinder.POS_RETRACTED: False,
+        Cylinder.POS_EXTENDED: False,
+        Cylinder.POS_INTERMEDIATE: True,
+    }
+
+    cyl.retract()
+    assert cyl.position == Cylinder.POS_RETRACTED
+    assert cyl.get_position_signals() == {
+        Cylinder.POS_RETRACTED: True,
+        Cylinder.POS_EXTENDED: False,
+        Cylinder.POS_INTERMEDIATE: False,
+    }

--- a/tests/test_slmp.py
+++ b/tests/test_slmp.py
@@ -1,0 +1,11 @@
+from slmp import SLMPMessage
+
+
+def test_slmp_encode_decode_roundtrip():
+    msg = SLMPMessage(command="RD", address=0x100, data=b"abc")
+    encoded = msg.encode()
+    decoded = SLMPMessage.decode(encoded)
+
+    assert decoded.command == msg.command
+    assert decoded.address == msg.address
+    assert decoded.data == msg.data


### PR DESCRIPTION
## Summary
- implement a minimal `Cylinder` class and `SLMPMessage` helper
- add pytest tests for cylinder state transitions and SLMP message handling
- document how to run tests in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f9d9a60008329ab1c0edb1b8de2b0