### PR TITLE
Add install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@
 - Python 3.x
 - [pytest](https://docs.pytest.org/)（テストを実行する場合）
 
+## インストール
+
+以下のコマンドでテスト実行に必要なパッケージをインストールします。
+
+```bash
+pip install pytest
+```
+
 ## 使い方
 
 ### シリンダーモデル `cylinder.py`


### PR DESCRIPTION
## Summary
- add package installation instructions for pytest in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fa12284788329bf9fb3cc66cc4991